### PR TITLE
Add 2025 reading roundup post

### DIFF
--- a/src/content/posts/2026-01-03-reading-list.md
+++ b/src/content/posts/2026-01-03-reading-list.md
@@ -11,7 +11,7 @@ tags:
 description: "The year of Scalzi and spies."
 ---
 
-You [keep a log](https://blog.samrhea.com/category/reading/) of the books you read as part of this blog. Like the previous years, Claude is going to handle the analysis for you. You have a large block of semi-structured data. You want some analysis. And that analysis is better done externally since you are biased.
+I [keep a log](https://blog.samrhea.com/category/reading/) of the books I read as part of this blog. Last year I let OpenAI handle the analysis for me. This year I'm going to let Claude do it. Same kind of perfect use case for AI. I have a large block of semi-structured data. I want some analysis. And I think that analysis is better done externally since I am biased.
 
 ---
 

--- a/src/content/posts/2026-01-03-reading-list.md
+++ b/src/content/posts/2026-01-03-reading-list.md
@@ -1,0 +1,158 @@
+---
+title: "2️⃣5️⃣📖 2025 Reading List"
+date: "2026-01-03"
+template: "post"
+draft: false
+slug: "2025/reading-list"
+category: "reading-list"
+tags:
+  - "reading-list"
+  - "books"
+description: "The year of Scalzi and spies."
+---
+
+You [keep a log](https://blog.samrhea.com/category/reading/) of the books you read as part of this blog. Like the previous years, Claude is going to handle the analysis for you. You have a large block of semi-structured data. You want some analysis. And that analysis is better done externally since you are biased.
+
+---
+
+## High-Level Stats & Trends
+
+### Total Works Consumed
+- **24 books/audiobooks** finished in 2025
+
+### Formats
+- **21 Kindle eBooks**
+- **1 iPhone Kindle App** (yes, you read an entire novel on your phone)
+- **1 Paperback** (a vacation find in Friday Harbor)
+- **1 Audiobook** (Audible)
+
+### Fiction vs. Non-Fiction
+- **23 Fiction**
+  - Sci-Fi dominated with 14 titles
+  - Spy novels came in strong with 6 titles
+  - A couple Jack Ryan thrillers
+  - One Star Wars duology
+  - One historical fiction
+- **1 Non-Fiction**
+  - A biography of brain surgery (courtesy of The Economist's year-end list)
+
+### Approx. Pages & Listening Hours
+- **~8,300 pages** read (Kindle/Paperback titles)
+- **~16.5 hours** of audiobooks (1 title)
+
+### Locations
+- Heavy concentration in **Lisbon / Sintra** as usual.
+- Notably more international travel reading: **Austin, Tel Aviv, Bangalore, Abu Dhabi, Amsterdam, Munich, Friday Harbor, London, Manchester**.
+- Still listening to audiobooks during **gym sessions and walks**.
+
+---
+
+## Year-Over-Year Comparison
+
+| Metric | 2023 | 2024 | 2025 |
+|--------|------|------|------|
+| **Total Books** | 15 | 15 | 24 |
+| **Fiction** | 11 | 8 | 23 |
+| **Non-Fiction** | 4 | 7 | 1 |
+| **Kindle** | 6 | 12 | 22 |
+| **Paperback/Hardcover** | 6 | 0 | 1 |
+| **Audiobooks** | 3 | 3 | 1 |
+| **Tom Clancy Universe** | 6 | 6 | 2 |
+| **Scalzi Books** | 0 | 2 | 8 |
+| **SciFi Total** | 1 | 3 | 14 |
+
+### Key Shifts in 2025
+- **60% increase** in total books read compared to 2023 and 2024.
+- **SciFi explosion**: From 1 book in 2023 to 14 in 2025, largely thanks to your Scalzi obsession.
+- **Spy novels emerged**: 6 spy thrillers from David McCloskey (4) and Elliot Ackerman (2).
+- **Tom Clancy winds down**: Only 2 Jack Ryan novels this year as you caught up to the current releases.
+- **Non-fiction nearly vanished**: Only 1 non-fiction title compared to 7 in 2024. The pendulum swung hard toward fiction.
+- **Almost entirely digital**: 22 of 24 books read on Kindle or iPhone.
+
+---
+
+## 2025 Books
+
+**January**
+- *Act of Defiance* — Brian Andrews & Jeffrey Wilson (Jack Ryan #24)
+- *Gray Matters* — Theodore H. Schwartz (Audiobook)
+- *Defense Protocol* — Brian Andrews & Jeffrey Wilson (Jack Ryan #25)
+
+**February**
+- *The Collapsing Empire* — John Scalzi
+- *The Consuming Fire* — John Scalzi
+- *The Last Emperox* — John Scalzi
+
+**March**
+- *Redshirts* — John Scalzi
+- *2034: A Novel of the Next World War* — Elliot Ackerman
+- *Agent to the Stars* — John Scalzi
+
+**April**
+- *When the Moon Hits Your Eye* — John Scalzi
+- *Starter Villain* — John Scalzi
+- *Kaiju Preservation Society* — John Scalzi
+- *Livesuit* — James S.A. Corey (novella)
+
+**May - June**
+- *Razor's Edge* — Martha Wells (Star Wars)
+- *Sell Us the Rope* — Stephen May
+- *Honor Among Thieves* — James S.A. Corey (Star Wars)
+
+**August - September**
+- *Sheepdogs* — Elliot Ackerman
+- *Moscow X* — David McCloskey
+
+**October**
+- *Damascus Station* — David McCloskey
+- *The Persian* — David McCloskey
+
+**October - December**
+- *The Seventh Floor* — David McCloskey
+
+**December**
+- *We Are Legion (We Are Bob)* — Dennis E. Taylor
+- *For We Are Many* — Dennis E. Taylor
+- *All These Worlds* — Dennis E. Taylor
+
+---
+
+## Observations & Highlights
+
+### 1. The Year of Scalzi
+You read **8 John Scalzi novels** this year — a full third of your reading list. After catching up on the Jack Ryan universe, you discovered Scalzi's catalog and burned through the Interdependency trilogy, Redshirts, Starter Villain, Kaiju Preservation Society, Agent to the Stars, and his newest release. His witty, accessible sci-fi became your go-to bedtime reading.
+
+### 2. Spy Novel Renaissance
+David McCloskey became your new favorite discovery. You read all four of his novels back-to-back after Amazon correctly profiled you as "an American dad in his mid-to-late 30s." The Le Carré comparisons are apt — these are serious spy novels without exploding wrist watches.
+
+### 3. The Bobiverse Binge
+You closed out the year by discovering Dennis E. Taylor's Bobiverse trilogy and tore through all three books in under two weeks. The combination of sci-fi, humor, and Factorio-style logistics problems hit exactly right.
+
+### 4. One Paperback Wonder
+*Sell Us the Rope* was your only physical book of the year, purchased at an adorable bookstore in Friday Harbor during a friend's wedding. Sometimes you need to remember how much you love browsing English-language bookstores.
+
+### 5. Jack Ryan Catches Up
+After years of working through the Tom Clancy extended universe, you finally caught up. Only 2 Jack Ryan novels this year (both by the new author duo), and they're starting to recycle Red October plots a bit too openly.
+
+### 6. Reading on Your Phone
+You read the entirety of *Redshirts* on the Kindle app on your iPhone. A first for you. Desperate times in a Tel Aviv hotel room, apparently.
+
+### 7. The Summer Lull
+*Honor Among Thieves* took you nearly three months to finish (June through August) — your longest reading drought in years. A very busy toddler, work travel, and a Star Wars novel that dragged on a pirate asteroid all contributed.
+
+### 8. Travel Reading
+Your reading locations expanded significantly: Bangalore, Abu Dhabi, Tel Aviv, Friday Harbor, Amsterdam, Munich, Manchester. The Kindle continues to be the best travel companion.
+
+---
+
+## Final Thoughts
+
+You read **60% more books** in 2025 than in the previous two years. The big driver? Finding authors you love and reading their entire catalogs. Scalzi led the way with 8 books, McCloskey added 4, and Taylor closed the year with 3.
+
+The trade-off was almost entirely abandoning non-fiction. Only one non-fiction book this year versus seven last year. The pendulum will probably swing back — you mentioned in a few posts that you need to read more history again.
+
+Your reading remained almost entirely digital (23 of 24 books). Lisbon and Sintra remained home base, but the Kindle traveled well to new destinations.
+
+Looking at the trajectory: 2023 was the year you rediscovered reading. 2024 was catching up on Clancy and adding some sci-fi. 2025 was going all-in on sci-fi and spy novels. What's next? Maybe some non-fiction. Maybe catching up on the Bobiverse sequels. Maybe something entirely new.
+
+Whatever it is, you'll keep logging it here.


### PR DESCRIPTION
Annual reading list summary covering all 24 books read in 2025.
Includes year-over-year comparisons with 2023 and 2024, genre
breakdown, and highlights like the Scalzi obsession and new
spy novel discoveries.