### PR TITLE
Optimize filter switching with client-side filtering

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,50 +1,219 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import FilterBar from '../components/FilterBar.astro';
-import PostCard from '../components/PostCard.astro';
-import Pagination from '../components/Pagination.astro';
 import { getAllContent } from '../utils/data';
 
 export const prerender = false;
 
 const allPosts = await getAllContent();
 const filter = Astro.url.searchParams.get('filter') || 'all';
-
-const filteredPosts = allPosts.filter(post => {
-    const isReading = post.category === 'reading' || post.tags.includes('reading');
-    if (filter === 'all') return !isReading;
-    if (filter === 'starred') return post.tags.includes('hits');
-    return post.category === filter || post.tags.includes(filter);
-});
-
 const pageParam = Astro.url.searchParams.get('page');
 const currentPage = pageParam ? parseInt(pageParam) : 1;
-const postsPerPage = 15;
-const totalPages = Math.ceil(filteredPosts.length / postsPerPage);
-const startIndex = (currentPage - 1) * postsPerPage;
-const paginatedPosts = filteredPosts.slice(startIndex, startIndex + postsPerPage);
+
+// Serialize posts for client-side filtering
+const postsData = allPosts.map(post => ({
+    title: post.title,
+    date: post.date.toISOString(),
+    url: post.url,
+    description: post.description || '',
+    category: post.category || '',
+    tags: post.tags || [],
+    isExternal: post.isExternal
+}));
+
+const filters = [
+    { label: 'All', value: 'all' },
+    { label: 'Highlights', value: 'starred' },
+    { label: 'Reading', value: 'reading' },
+    { label: 'Portugal', value: 'portugal' },
+    { label: 'Texas', value: 'texas' },
+    { label: 'Cloudflare', value: 'cloudflare' },
+];
 ---
 
 <Layout title="Writing — Sam Rhea">
     <header class="mb-8">
-        <FilterBar activeFilter={filter} />
+        <div class="flex flex-wrap gap-1" id="filter-bar">
+            {filters.map((f) => (
+                <button
+                    type="button"
+                    data-filter={f.value}
+                    class:list={[
+                        "filter-btn px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150",
+                        filter === f.value
+                            ? "bg-white text-midnight-950"
+                            : "text-midnight-500 hover:text-midnight-200 hover:bg-midnight-900/50"
+                    ]}
+                >
+                    {f.label}
+                </button>
+            ))}
+        </div>
     </header>
 
-    <section class="divide-y divide-midnight-800/30">
-        {paginatedPosts.length === 0 ? (
-            <p class="text-midnight-500 py-8">No posts found.</p>
-        ) : (
-            paginatedPosts.map((post) => (
-                <PostCard 
-                    title={post.title}
-                    date={post.date}
-                    url={post.url}
-                    description={post.description}
-                    isExternal={post.isExternal}
-                />
-            ))
-        )}
+    <section id="posts-list" class="divide-y divide-midnight-800/30">
+        <!-- Posts rendered by JS -->
     </section>
 
-    <Pagination currentPage={currentPage} totalPages={totalPages} filter={filter} />
+    <nav id="pagination" class="mt-16 pt-6 border-t border-midnight-800/40 hidden">
+        <!-- Pagination rendered by JS -->
+    </nav>
 </Layout>
+
+<script define:vars={{ postsData, initialFilter: filter, initialPage: currentPage }}>
+    const POSTS_PER_PAGE = 15;
+    let currentFilter = initialFilter;
+    let currentPage = initialPage;
+
+    function filterPosts(posts, filter) {
+        return posts.filter(post => {
+            const isReading = post.category === 'reading' || post.tags.includes('reading');
+            if (filter === 'all') return !isReading;
+            if (filter === 'starred') return post.tags.includes('hits');
+            return post.category === filter || post.tags.includes(filter);
+        });
+    }
+
+    function formatDate(dateStr) {
+        const d = new Date(dateStr);
+        return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
+    }
+
+    function renderPosts(posts, page) {
+        const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE);
+        const startIndex = (page - 1) * POSTS_PER_PAGE;
+        const paginatedPosts = posts.slice(startIndex, startIndex + POSTS_PER_PAGE);
+
+        const container = document.getElementById('posts-list');
+
+        if (paginatedPosts.length === 0) {
+            container.innerHTML = '<p class="text-midnight-500 py-8">No posts found.</p>';
+        } else {
+            container.innerHTML = paginatedPosts.map(post => `
+                <article class="group py-4 -mx-3 px-3 rounded-lg hover:bg-midnight-900/30 transition-colors duration-150">
+                    <a
+                        href="${post.url}"
+                        ${post.isExternal ? 'target="_blank" rel="noopener noreferrer"' : ''}
+                        class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-6"
+                    >
+                        <time class="flex-shrink-0 w-20 text-xs font-mono text-midnight-500 tabular-nums">
+                            ${formatDate(post.date)}
+                        </time>
+                        <div class="flex-grow min-w-0">
+                            <h2 class="text-[15px] font-medium text-midnight-200 group-hover:text-white transition-colors duration-150 flex items-center gap-2">
+                                <span class="truncate">${post.title}</span>
+                                ${post.isExternal ? `
+                                    <svg class="w-3 h-3 flex-shrink-0 text-midnight-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                    </svg>
+                                ` : ''}
+                            </h2>
+                            ${post.description ? `
+                                <p class="mt-1 text-sm text-midnight-400 line-clamp-1">
+                                    ${post.description}
+                                </p>
+                            ` : ''}
+                        </div>
+                    </a>
+                </article>
+            `).join('');
+        }
+
+        renderPagination(page, totalPages);
+    }
+
+    function renderPagination(page, totalPages) {
+        const nav = document.getElementById('pagination');
+
+        if (totalPages <= 1) {
+            nav.classList.add('hidden');
+            return;
+        }
+
+        nav.classList.remove('hidden');
+        nav.innerHTML = `
+            <div>
+                ${page > 1 ? `
+                    <button type="button" data-page="${page - 1}" class="page-btn text-sm text-midnight-500 hover:text-white transition-colors duration-150 flex items-center gap-1">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                        </svg>
+                        Newer
+                    </button>
+                ` : '<span></span>'}
+            </div>
+            <span class="text-xs font-mono text-midnight-700 tabular-nums">${page}/${totalPages}</span>
+            <div>
+                ${page < totalPages ? `
+                    <button type="button" data-page="${page + 1}" class="page-btn text-sm text-midnight-500 hover:text-white transition-colors duration-150 flex items-center gap-1">
+                        Older
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                        </svg>
+                    </button>
+                ` : '<span></span>'}
+            </div>
+        `;
+        nav.classList.add('flex', 'items-center', 'justify-between');
+    }
+
+    function updateURL(filter, page) {
+        const url = new URL(window.location.href);
+        url.searchParams.set('filter', filter);
+        if (page > 1) {
+            url.searchParams.set('page', page.toString());
+        } else {
+            url.searchParams.delete('page');
+        }
+        history.pushState({ filter, page }, '', url);
+    }
+
+    function updateFilterButtons(activeFilter) {
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            const isActive = btn.dataset.filter === activeFilter;
+            btn.classList.toggle('bg-white', isActive);
+            btn.classList.toggle('text-midnight-950', isActive);
+            btn.classList.toggle('text-midnight-500', !isActive);
+            btn.classList.toggle('hover:text-midnight-200', !isActive);
+            btn.classList.toggle('hover:bg-midnight-900/50', !isActive);
+        });
+    }
+
+    function applyFilter(filter, page = 1, pushState = true) {
+        currentFilter = filter;
+        currentPage = page;
+        const filtered = filterPosts(postsData, filter);
+        renderPosts(filtered, page);
+        updateFilterButtons(filter);
+        if (pushState) {
+            updateURL(filter, page);
+        }
+    }
+
+    // Initial render
+    applyFilter(currentFilter, currentPage, false);
+
+    // Filter button click handlers
+    document.getElementById('filter-bar').addEventListener('click', (e) => {
+        const btn = e.target.closest('.filter-btn');
+        if (btn) {
+            applyFilter(btn.dataset.filter, 1);
+        }
+    });
+
+    // Pagination click handlers (event delegation)
+    document.getElementById('pagination').addEventListener('click', (e) => {
+        const btn = e.target.closest('.page-btn');
+        if (btn) {
+            const page = parseInt(btn.dataset.page);
+            applyFilter(currentFilter, page);
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+    });
+
+    // Handle browser back/forward
+    window.addEventListener('popstate', (e) => {
+        if (e.state) {
+            applyFilter(e.state.filter, e.state.page || 1, false);
+        }
+    });
+</script>


### PR DESCRIPTION
Replace server-side filtering with client-side JavaScript to eliminate
full page reloads when switching filters. Posts data is now embedded as
JSON and filtering/pagination happens instantly in the browser.

- Embed all posts data in page as serialized JSON
- Add client-side filterPosts(), renderPosts(), renderPagination()
- Use history.pushState() to update URL without navigation
- Handle browser back/forward with popstate event
- Convert filter links to buttons with click handlers
- Eliminates prefetch 503 errors from Cloudflare speculation rules