### PR TITLE
Add wrangler ^4.21.0 for Cloudflare preview URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "@tailwindcss/vite": "^4.1.17",
         "astro": "^5.16.0",
         "tailwindcss": "^3.4.18"
+      },
+      "devDependencies": {
+        "wrangler": "^4.21.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "@tailwindcss/vite": "^4.1.17",
     "astro": "^5.16.0",
     "tailwindcss": "^3.4.18"
+  },
+  "devDependencies": {
+    "wrangler": "^4.21.0"
   }
 }


### PR DESCRIPTION
Added wrangler as a devDependency to enable aliased preview URLs
for Workers deployments on non-production branches.