### PR TITLE
Link to previous years' reading lists in 2025 post

### DIFF
--- a/src/content/posts/2026-01-03-reading-list.md
+++ b/src/content/posts/2026-01-03-reading-list.md
@@ -11,7 +11,7 @@ tags:
 description: "The year of Scalzi and spies."
 ---
 
-I [keep a log](https://blog.samrhea.com/category/reading/) of the books I read as part of this blog. Last year I let OpenAI handle the analysis for me. This year I'm going to let Claude do it. Same kind of perfect use case for AI. I have a large block of semi-structured data. I want some analysis. And I think that analysis is better done externally since I am biased.
+I [keep a log](https://blog.samrhea.com/?filter=reading) of the books I read as part of this blog. [Last year](https://blog.samrhea.com/posts/2024/reading-list/) I let OpenAI handle the analysis for me. [The year before](https://blog.samrhea.com/posts/2023/reading-list/) I did it manually. This year I'm going to let Claude do it. Same kind of perfect use case for AI. I have a large block of semi-structured data. I want some analysis. And I think that analysis is better done externally since I am biased.
 
 ---
 


### PR DESCRIPTION
Update the first paragraph to link "keep a log" to the reading filter
page and add links to the 2024 and 2023 reading list posts.